### PR TITLE
Update embedding.py

### DIFF
--- a/utilss/embedding.py
+++ b/utilss/embedding.py
@@ -34,7 +34,7 @@ except:
     Log.logger.warning(f"embedding模型未安装，开始安装embedding模型...")
     model_id = "iic/nlp_gte_sentence-embedding_chinese-base"
     local_dir = "./utilss/models/nlp_gte_sentence-embedding_chinese-base"
-    snapshot_download(model_id = model_id, local_dir=local_dir)
+    snapshot_download(model_id=model_id, cache_dir=local_dir)   # Using local_dir=local_dir caused problem on Linux.
     embedding_model = load_model()
 
 def t2vect(text: list[str]) -> np.ndarray[np.ndarray]:


### PR DESCRIPTION
Using "snapshot_download(model_id = model_id, local_dir=local_dir)" caused problems on Linux.

Fixed by:snapshot_download(model_id=model_id, cache_dir=local_dir)